### PR TITLE
Pull Request da filtragem de pares

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ fn executar_estrategia(lista: &mut Vec<i64>, estrategia: fn(&mut Vec<i64>));
 ```
 
 ### 1. `ordemCrescente` (Ordenação por Insertion Sort)
+> Autor: Gustavo dos Santos Leão
+
 A função **`ordemCrescente`** é responsável por ordenar um vetor de números inteiros em ordem crescente usando o algoritmo **Insertion Sort**. Esse algoritmo percorre o vetor e insere cada elemento na posição correta dentro da parte já ordenada.
 
 **Assinatura:**
@@ -22,9 +24,18 @@ fn ordemCrescente(lista: &mut Vec<i64>)
 ```
 
 ### 2. ordena_decrescente (Ordenação por Insertion Sort)
+> Autor: Heuller Ramos Vieira
+
 A função **ordena_decrescente** é responsável por ordenar um vetor de números inteiros em ordem decrescente usando o algoritmo *Insertion Sort*. Esse algoritmo percorre o vetor e insere cada elemento na posição correta dentro da parte já ordenada.
 
-### 3. `removeDuplicatas` 
+**Assinatura:**
+```rust
+fn ordem_decrescente(lista: &mut Vec<i64>)
+```
+
+### 3. `removeDuplicatas`
+> Autor: Bernardo Ruas Oliveira
+
 A função **`removeDuplicatas`** implementa um algoritmo eficiente para remover elementos duplicados de um vetor (Vec<i64>), preservando a ordem da primeira aparição de cada elemento. Para garantir um desempenho otimizado, a função emprega um HashSet para rastrear os valores já vistos. A remoção dos itens é realizada através do método "retain", que avalia cada elemento e o mantém apenas se for a primeira vez que ele é encontrado.
 
 **Assinatura:**
@@ -32,3 +43,12 @@ A função **`removeDuplicatas`** implementa um algoritmo eficiente para remover
 fn removeDuplicatas(lista: &mut Vec<i64>)
 ```
 
+### 4. `filtrar_pares` 
+> Autor: André Felipe de Oliveira Lopes
+
+A função **`filtrar_pares`** recebe um vetor mutável de inteiros e filtra apenas os números pares. Especificamente, a função contém um loop, o qual permite a iteração por todos os elementos do vetor. Dentro deste loop, há uma condição que verifica se o resto da divisão do elemento atual por 2 resulta em zero. Caso sim, este elemento é adicionado no vetor de ´pares´. Neste caso, é possível perceber também que, se um elemento repetido aparecer, ele será novamente verificado e, se for par, será adicionado no vetor de ´pares´ da mesma forma. Ao término da iteração, um ponteiro do vetor principal recebe o vetor de ´pares´. Ou seja, o vetor original é atualizado. Como se trata de um ponteiro, a alteração é refletida em qualquer espaço do código, inclusive na função ´main´.
+
+**Assinatura:**
+```rust
+fn filtrar_pares(lista: &mut Vec<i64>)
+```

--- a/estrategias/filtrar_pares.rs
+++ b/estrategias/filtrar_pares.rs
@@ -1,0 +1,38 @@
+/// Filtra apenas os números pares do vetor de inteiros
+/// 
+/// Esta função percorre todos os elementos do vetor original e mantém
+/// apenas aqueles que são pares (divisíveis por 2). O vetor original é
+/// substituído pelo novo vetor contendo apenas os pares.
+/// 
+/// # Argumentos
+///
+/// * `vetor` - Um vetor mutável de números inteiros (`<i64>`) que será filtrado.
+///
+/// # Exemplo
+///
+/// ```
+/// let mut numeros = vec![1, 2, 3, 4, 5, 6];
+/// filtrar_pares(&mut numeros);
+/// assert_eq!(numeros, vec![2, 4, 6]);
+/// ```
+///
+/// # Observação
+///
+/// O vetor original é modificado. Os elementos ímpares são removidos.
+///
+/// # Complexidade
+///
+/// - Tempo: O(n), onde n é o tamanho do vetor.
+/// - Espaço adicional: O(n), para armazenar os pares temporariamente.
+
+pub fn filtrar_pares(vetor: &mut Vec<i64>) {
+    let mut pares = Vec::new();
+
+    for valor in vetor.iter() {
+        if valor % 2 == 0 {
+            pares.push(*valor);
+        } 
+
+    }
+    *vetor = pares;
+}

--- a/estrategias/mod.rs
+++ b/estrategias/mod.rs
@@ -1,3 +1,4 @@
 pub mod ordemCrescente;
 pub mod ordena_decrescente;
 pub mod removeDuplicatas;
+pub mod filtrar_pares;

--- a/estrategias/removeDuplicatas.rs
+++ b/estrategias/removeDuplicatas.rs
@@ -15,7 +15,7 @@
 
 
 use std::collections::HashSet;//para remover duplicatas
-fn removeDuplicatas(lista: &mut Vec<i64>) {
+pub fn removeDuplicatas(lista: &mut Vec<i64>) {
     // 1. Cria um HashSet para rastrear os elementos que já vimos.
     let mut vistos = HashSet::new();
 

--- a/main.rs
+++ b/main.rs
@@ -11,6 +11,7 @@ fn main() {
 
     executar_estrategia(&mut numeros, estrategias::ordemCrescente::ordemCrescente);
     executar_estrategia(&mut numeros, estrategias::ordena_decrescente::ordena_decrescente);
+    executar_estrategia(&mut numeros, estrategias::filtrar_pares::filtrar_pares);
     executar_estrategia(&mut numeros, estrategias::removeDuplicatas::removeDuplicatas);
     
 }


### PR DESCRIPTION
# Implementa função `filtrar_pares`

Basicamente, a função de filtrar pares recebe um parâmetro vetor, que é uma referência mutável para o vetor criado na main. Dentro da função, criei a variável `pares` que vai receber apenas os números pares dentro do laço que itera por todo o vetor principal. Após o laço ser finalizado, é possível garantir que pares contém apenas os valores mencionados, na ordem e na quantidade de vezes que aparecem. No fim, fiz o ponteiro para o vetor principal receber esse outro vetor `pares`, para que o vetor principal fique atualizado.

## Exemplo de uso

```rust
let numeros = vec![5, 5, 1, 0, 9, 8, 6, 2, 8, 5, 2, 9, 1, 0, 4, 4];
    println!("Lista original: {:?}", numeros);

    executar_estrategia(numeros, filtrar_pares);
// Agora `numeros` será: [0, 8, 6, 2, 8, 2, 0, 4, 4]
